### PR TITLE
fixes #4 CBT試験画面のボタン押下フィードバックテキスト機能の開発

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ It also fills the current tab button by other color to make distinguishable the 
 
 Source: `features/clickable_current_tab/all.content.js`
 
+
+### Solomon reanswer graphical feedback
+By default, when you modify answer in Solomon answer, Solomon doesn't any graphical response.
+
+This extension displays graphically whether requests of form submit has succeeded.
+
+Source: `features/solomon_reanswer_feedback_text/cbt_question.content.js`
+
 ## Usage
 
 1. Clone or download as zip file this repository.

--- a/features/helper/cbt_page_detect.content.js
+++ b/features/helper/cbt_page_detect.content.js
@@ -1,0 +1,3 @@
+const isExamPage = () => {
+  return document.querySelector(".btn-examanswer") != null;
+}

--- a/features/solomon_reanswer_feedback_text/cbt_question.background.js
+++ b/features/solomon_reanswer_feedback_text/cbt_question.background.js
@@ -1,0 +1,47 @@
+const sessionStorage = chrome.storage.session;
+
+// memorize answer endpoint URL we have to track now
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  console.log(chrome.storage.session);
+  if (request.type != "portalext_answer_fire") return;
+
+  // If the message is from not content script context
+  if (!session.tab) return;
+
+  // currentWatchingFormActionTarget should be managed by tab separately
+  const watchingTarget = {
+    currentWatchingFormActionTargetDict: {
+      [sender.tab.id]: request.form_action_target
+    }
+  }
+
+  sessionStorage.set(watchingTarget).then(() => {
+    console.debug(`[debug] currentWatchingFormActionTarget on ${sender.tab} was changed to ${request.form_action_target}`);
+  });
+});
+
+const processResponse = async (responseDetail) => {
+  //  we expect type of formActionTarget is { [tab in string]: string } 
+  const formActionTargetDict = await sessionStorage.get(["currentWatchingFormActionTargetDict"]);
+
+  const entries = Object.entries(formActionTargetDict);
+  for (const entry of entries) {
+    const [tabId, formActionTarget] = entry;
+    if (formActionTarget != responseDetail.URL) continue;
+
+    // completed finding a tab which is waiting a response from responseDetail.URL
+    const messagePayload = {
+      type: "portal_ext_answer_confirm",
+      isCompleted: responseDetail.statusCode == 200
+    };
+    chrome.tabs.sendMessage(tabId, messagePayload);
+    console.debug(`[debug] tab: ${tabId}, status: ${messagePayload.isCompleted ? "completed" : "unknown"}`)
+    break;
+  };
+}
+
+chrome.webRequest.onResponseStarted.addListener((responseDetail) => {
+  processResponse(responseDetail);
+}, {
+  urls: ["*://solomon.mc.chitose.ac.jp/wbt/*"]
+});

--- a/features/solomon_reanswer_feedback_text/cbt_question.background.js
+++ b/features/solomon_reanswer_feedback_text/cbt_question.background.js
@@ -53,6 +53,9 @@ const processResponse = async (responseDetail) => {
 chrome.webRequest.onResponseStarted.addListener((responseDetail) => {
   processResponse(responseDetail);
 }, {
-  urls: ["https://solomon.mc.chitose.ac.jp/wbt/*", "http://localhost:3000/*"],
+  urls: [
+    "https://solomon.mc.chitose.ac.jp/wbt/*"
+    /*, "http://localhost:3000/*"*/
+  ],
   types: ["xmlhttprequest"]
 });

--- a/features/solomon_reanswer_feedback_text/cbt_question.background.js
+++ b/features/solomon_reanswer_feedback_text/cbt_question.background.js
@@ -33,8 +33,6 @@ const processResponse = async (responseDetail) => {
   if (!currentWatchingActionDict) return;
 
   for (const tabIdString in currentWatchingActionDict) {
-    // tabId
-
     const tabId = Number.parseInt(tabIdString);
     const formActionTarget = currentWatchingActionDict[tabId];
     if (formActionTarget != responseDetail.url) continue;

--- a/features/solomon_reanswer_feedback_text/cbt_question.content.js
+++ b/features/solomon_reanswer_feedback_text/cbt_question.content.js
@@ -1,0 +1,35 @@
+const main_solomon_reanswer_feedback_text = () => {
+  const answerConfirmButtonContainer = document.querySelector(".examContentsButtonLayout");
+
+  if (!answerConfirmButtonContainer) return;
+  const answerConfirmButton = answerConfirmButtonContainer.querySelector("button");
+
+  answerConfirmButton.addEventListener("click", () => {
+    const questionForm = answerConfirmButton.form;
+    const messagePayload = {
+      type: "portalext_answer_fire",
+      form_action_target: questionForm.action
+    }
+    chrome.runtime.sendMessage(messagePayload);
+  });
+
+  const convertConfirmStatusToJapanese = (isCompleted) => {
+    if (isCompleted) {
+      return "答案の決定に成功しました。";
+    }
+    return "答案決定リクエストが失敗しました。開発者ツールを確認してください。";
+  }
+
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    const isConfirmMessage = request.type == "portalext_answer_confirm"
+    if (!isConfirmMessage) return;
+
+    const japaneseLabel = convertConfirmStatusToJapanese(request.completed);
+    const answerCompletedLabel = document.createElement("p");
+    answerCompletedLabel.textContent = japaneseLabel;
+    answerConfirmButtonContainer.appendChild(answerCompletedLabel);
+  });
+}
+
+if (isExamPage()) main_solomon_reanswer_feedback_text();
+console.log(isExamPage())

--- a/features/solomon_reanswer_feedback_text/cbt_question.content.js
+++ b/features/solomon_reanswer_feedback_text/cbt_question.content.js
@@ -24,7 +24,7 @@ const main_solomon_reanswer_feedback_text = () => {
     const isConfirmMessage = request.type == "portalext_answer_confirm"
     if (!isConfirmMessage) return;
 
-    const japaneseLabel = convertConfirmStatusToJapanese(request.completed);
+    const japaneseLabel = convertConfirmStatusToJapanese(request.isCompleted);
     const answerCompletedLabel = document.createElement("p");
     answerCompletedLabel.textContent = japaneseLabel;
     answerConfirmButtonContainer.appendChild(answerCompletedLabel);
@@ -32,4 +32,3 @@ const main_solomon_reanswer_feedback_text = () => {
 }
 
 if (isExamPage()) main_solomon_reanswer_feedback_text();
-console.log(isExamPage())

--- a/manifest.json
+++ b/manifest.json
@@ -40,8 +40,7 @@
         },
         {
             "matches": [
-                "https://solomon.mc.chitose.ac.jp/wbt/*",
-                "http://localhost:3000/*"
+                "https://solomon.mc.chitose.ac.jp/wbt/*"
             ],
             "js": [
                 "features/helper/cbt_page_detect.content.js",
@@ -58,7 +57,6 @@
         "webRequest"
     ],
     "host_permissions": [
-        "*://solomon.mc.chitose.ac.jp/wbt/*",
-        "http://localhost:3000/*"
+        "*://solomon.mc.chitose.ac.jp/wbt/*"
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -40,7 +40,8 @@
         },
         {
             "matches": [
-                "https://solomon.mc.chitose.ac.jp/wbt/*"
+                "https://solomon.mc.chitose.ac.jp/wbt/*",
+                "http://localhost:3000/*"
             ],
             "js": [
                 "features/helper/cbt_page_detect.content.js",
@@ -57,6 +58,7 @@
         "webRequest"
     ],
     "host_permissions": [
-        "*://solomon.mc.chitose.ac.jp/wbt/*"
+        "*://solomon.mc.chitose.ac.jp/wbt/*",
+        "http://localhost:3000/*"
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -37,9 +37,26 @@
             "css": [
                 "features/clickable_current_tab/all.content.css"
             ]
+        },
+        {
+            "matches": [
+                "https://solomon.mc.chitose.ac.jp/wbt/*"
+            ],
+            "js": [
+                "features/helper/cbt_page_detect.content.js",
+                "features/solomon_reanswer_feedback_text/cbt_question.content.js"
+            ],
+            "all_frames": true
         }
     ],
     "background": {
-        "service_worker": "service_worker.js"
-    }
+        "service_worker": "features/solomon_reanswer_feedback_text/cbt_question.background.js"
+    },
+    "permissions": [
+        "storage",
+        "webRequest"
+    ],
+    "host_permissions": [
+        "*://solomon.mc.chitose.ac.jp/wbt/*"
+    ]
 }


### PR DESCRIPTION
# 概要
fixes #4

CBTの試験画面で、回答ボタンを押下しても、リクエストが処理されたのかが分からない。
このPRでは、Service Workerを用い、formのactionからのレスポンスを取得する。

https://github.com/coolwind0202/portalext/blob/e2d93b85b7fbb5eb40c43ab694185681fe83d682/features/solomon_reanswer_feedback_text/cbt_question.background.js#L53-L61

formからレスポンスが返却されたタイミングで、divタグ内にp要素で回答処理の完了をユーザーに通知する。
https://github.com/coolwind0202/portalext/blob/e2d93b85b7fbb5eb40c43ab694185681fe83d682/features/solomon_reanswer_feedback_text/cbt_question.content.js#L28-L30

